### PR TITLE
Updated link to miscellaneous examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ List of all links you can try with ULX3S. See also [ulx3s.github.io](https://ulx
 * [http://github.com/emard/ulx3s](http://github.com/emard/ulx3s)
 ##  Getting Started
 
-* [https://github.com/emard/ulx3s-examples](https://github.com/emard/ulx3s-examples/blob/master/README.md)
+* [https://github.com/emard/ulx3s-misc](https://github.com/emard/ulx3s-misc/blob/master/README.md)
 
 * [https://github.com/emard/ulx3s-bin](https://github.com/emard/ulx3s-bin) 
 


### PR DESCRIPTION
Under Getting Started, the link to https://github.com/emard/ulx3s-examples/blob/master/README.md was returning a 404 error. I updated it to what I believe was just a renamed repository.