### PR TITLE
Add new link for another softcore supporting ULX3S

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ List of all links you can try with ULX3S. See also [ulx3s.github.io](https://ulx
 
 * [ULX3S WSL/Ubuntu Toolchain Open Source Install](https://gist.github.com/gojimmypi/f96cd86b2b8595b4cf3be4baf493c5a7) 
 
+Risc-V 32 Implementation in VHDL
+* [https://github.com/stnolting/neorv32](https://github.com/stnolting/neorv32)
+
 ##  Advanced examples
 
 Sources are prepared to compile with both open and closed source tools


### PR DESCRIPTION
Hello, two weeks ago some colleagues and me released a new version of "neorv32" (Risc-V 32 softcore implemented in VHDL, https://github.com/stnolting/neorv32 ) compatible with your amazing board, I would like to be mention as a supported project if you like.
Thanks!